### PR TITLE
Add idle tycoon Unity project scaffolding

### DIFF
--- a/Assets/Art/UI/Placeholders/placeholder.txt
+++ b/Assets/Art/UI/Placeholders/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder sprite metadata goes here.

--- a/Assets/Art/UI/Placeholders/sample_balance.csv
+++ b/Assets/Art/UI/Placeholders/sample_balance.csv
@@ -1,0 +1,4 @@
+level,cost,cumulative_spend,income_mult_from_upgrade,global_mult_from_milestones
+1,10,10,1.0,1.0
+2,11.2,21.2,1.1,1.0
+3,12.5,33.7,1.2,1.0

--- a/Assets/Docs/PRIVACY_POLICY_TEMPLATE.md
+++ b/Assets/Docs/PRIVACY_POLICY_TEMPLATE.md
@@ -1,0 +1,3 @@
+# Privacy Policy Template
+
+Describe data collection, usage of Firebase Analytics/Remote Config, AdMob, and Unity IAP. Outline consent flow with Google UMP and provide contact information.

--- a/Assets/Docs/README.md
+++ b/Assets/Docs/README.md
@@ -1,0 +1,22 @@
+# Growth Idle Tycoon
+
+Unity 2022.3 URP 2D project targeting Android portrait. Core loop: tap + idle income, upgrades, prestige, rewarded ads, and IAP.
+
+## Getting Started
+1. Open with Unity 2022.3 LTS or newer.
+2. Scenes: load `Scenes/Bootstrap.unity` for startup.
+3. Player Settings: Android, IL2CPP, ARM64, min SDK 24, portrait only, VSync disabled.
+
+## Services Configuration
+- **AdMob**: Replace IDs in `Resources/Config/AdConfig.asset`.
+- **Unity IAP**: Configure product metadata in `Resources/Config/IAPConfig.asset` and set up in Unity Dashboard.
+- **Firebase**: Hook `RemoteConfigService` and `AnalyticsService` into Firebase SDK.
+
+## Testing
+Run EditMode and PlayMode tests via Unity Test Runner.
+
+## Debugging
+Define scripting symbol `DEV` to enable in-game debug console and panel.
+
+## Privacy
+See `PRIVACY_POLICY_TEMPLATE.md` for store submission.

--- a/Assets/Docs/RELEASE_CHECKLIST.md
+++ b/Assets/Docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,9 @@
+# Release Checklist
+- [ ] Update package name and version.
+- [ ] Configure keystore for Android.
+- [ ] Replace placeholder AdMob IDs in `Resources/Config/AdConfig.asset`.
+- [ ] Ensure Firebase Analytics/Remote Config SDKs integrated and privacy policy URL updated.
+- [ ] Verify Unity IAP product IDs and descriptions.
+- [ ] Complete Google Play Data Safety form and GDPR consent flow.
+- [ ] Build with IL2CPP, ARM64, min SDK 24, portrait orientation.
+- [ ] Run internal test track and verify rewarded ads, IAP, and prestige loops.

--- a/Assets/Editor/Balancing/CSVImportWindow.cs
+++ b/Assets/Editor/Balancing/CSVImportWindow.cs
@@ -1,0 +1,54 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using System.IO;
+using Game.Core.Economy.UpgradeSystem;
+using UnityEditor;
+using UnityEngine;
+
+namespace Game.EditorTools.Balancing
+{
+    public class CSVImportWindow : EditorWindow
+    {
+        private TextAsset _csv;
+        private UpgradeDefinition _target;
+
+        [MenuItem("Game/Balancing/CSV Importer")]
+        public static void ShowWindow()
+        {
+            GetWindow<CSVImportWindow>(false, "CSV Import");
+        }
+
+        private void OnGUI()
+        {
+            _csv = (TextAsset)EditorGUILayout.ObjectField("CSV", _csv, typeof(TextAsset), false);
+            _target = (UpgradeDefinition)EditorGUILayout.ObjectField("Upgrade", _target, typeof(UpgradeDefinition), false);
+
+            if (GUILayout.Button("Import") && _csv != null && _target != null)
+            {
+                ApplyCsv(_csv.text, _target);
+            }
+        }
+
+        private void ApplyCsv(string text, UpgradeDefinition definition)
+        {
+            using var reader = new StringReader(text);
+            string line;
+            var lines = new List<string>();
+            while ((line = reader.ReadLine()) != null)
+            {
+                lines.Add(line);
+            }
+
+            if (lines.Count > 1)
+            {
+                var second = lines[1].Split(',');
+                if (second.Length > 1 && double.TryParse(second[1], out var startCost))
+                {
+                    definition.CostCurve.StartCost = startCost;
+                    EditorUtility.SetDirty(definition);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Assets/Editor/SafeArea/SafeAreaHelper.cs
+++ b/Assets/Editor/SafeArea/SafeAreaHelper.cs
@@ -1,0 +1,42 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Game.EditorTools.SafeArea
+{
+    [ExecuteAlways]
+    public class SafeAreaHelper : MonoBehaviour
+    {
+        private Rect _lastSafeArea;
+
+        private void Update()
+        {
+            ApplySafeArea();
+        }
+
+        private void ApplySafeArea()
+        {
+            var safe = Screen.safeArea;
+            if (safe == _lastSafeArea)
+            {
+                return;
+            }
+
+            _lastSafeArea = safe;
+            var panel = GetComponent<RectTransform>();
+            if (panel == null)
+            {
+                return;
+            }
+
+            Vector2 anchorMin = safe.position;
+            Vector2 anchorMax = safe.position + safe.size;
+            anchorMin.x /= Screen.width;
+            anchorMin.y /= Screen.height;
+            anchorMax.x /= Screen.width;
+            anchorMax.y /= Screen.height;
+
+            panel.anchorMin = anchorMin;
+            panel.anchorMax = anchorMax;
+        }
+    }
+}

--- a/Assets/Resources/Config/AdConfig.asset
+++ b/Assets/Resources/Config/AdConfig.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_Name: AdConfig
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}
+  AndroidRewardedId: ca-app-pub-3940256099942544/5224354917
+  IOSRewardedId: ""

--- a/Assets/Resources/Config/EconomyConfig.asset
+++ b/Assets/Resources/Config/EconomyConfig.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_Name: EconomyConfig
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}
+  BaseIncome: 1
+  OfflineFactor: 0.7

--- a/Assets/Resources/Config/IAPConfig.asset
+++ b/Assets/Resources/Config/IAPConfig.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_Name: IAPConfig
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}
+  Products:
+  - ProductId: com.leon.idle.starterpack
+    Title: Starter Pack
+    Description: 500 Gems + Remove Ads
+    PriceString: $4.99
+  - ProductId: com.leon.idle.removeads
+    Title: Remove Ads
+    Description: Removes banner and rewarded ads cooldowns
+    PriceString: $2.99
+  - ProductId: com.leon.idle.monthlybooster
+    Title: Monthly Booster
+    Description: 30 day +10% income boost
+    PriceString: $5.99

--- a/Assets/Resources/Upgrades/Income.asset
+++ b/Assets/Resources/Upgrades/Income.asset
@@ -1,0 +1,9 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_Name: Income
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}
+  Id: income
+  DisplayName: Income/sec
+  Description: Increases idle income

--- a/Assets/Resources/Upgrades/Offline.asset
+++ b/Assets/Resources/Upgrades/Offline.asset
@@ -1,0 +1,9 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_Name: Offline
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}
+  Id: offline
+  DisplayName: Offline Earnings
+  Description: Improves offline multiplier

--- a/Assets/Resources/Upgrades/Tap.asset
+++ b/Assets/Resources/Upgrades/Tap.asset
@@ -1,0 +1,9 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_Name: Tap
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}
+  Id: tap
+  DisplayName: Tap Power
+  Description: Boosts tap gains

--- a/Assets/Scenes/Bootstrap.unity
+++ b/Assets/Scenes/Bootstrap.unity
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Bootstrap
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  m_Layer: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_GameObject: {fileID: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &3
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 0}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Canvas
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &2
+RectTransform:
+  m_GameObject: {fileID: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}

--- a/Assets/Scripts/Core/DebugTools/DebugConsole.cs
+++ b/Assets/Scripts/Core/DebugTools/DebugConsole.cs
@@ -1,0 +1,34 @@
+#if DEV
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Core.DebugTools
+{
+    public class DebugConsole : MonoBehaviour
+    {
+        private readonly Queue<string> _logs = new();
+        [SerializeField] private UnityEngine.UI.Text _output;
+
+        private void OnEnable()
+        {
+            Application.logMessageReceived += HandleLog;
+        }
+
+        private void OnDisable()
+        {
+            Application.logMessageReceived -= HandleLog;
+        }
+
+        private void HandleLog(string condition, string stackTrace, LogType type)
+        {
+            _logs.Enqueue(condition);
+            while (_logs.Count > 20)
+            {
+                _logs.Dequeue();
+            }
+
+            _output.text = string.Join("\n", _logs);
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Core/DebugTools/DebugPanelController.cs
+++ b/Assets/Scripts/Core/DebugTools/DebugPanelController.cs
@@ -1,0 +1,40 @@
+#if DEV
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.Core.DebugTools
+{
+    public class DebugPanelController : MonoBehaviour
+    {
+        [SerializeField] private GameObject _panel;
+        [SerializeField] private Button _grantCoinsButton;
+        private int _tapCount;
+        private float _lastTapTime;
+
+        private void Awake()
+        {
+            _panel.SetActive(false);
+            _grantCoinsButton.onClick.AddListener(() => Debug.Log("Grant coins"));
+        }
+
+        public void OnVersionLabelTapped()
+        {
+            if (Time.unscaledTime - _lastTapTime < 0.5f)
+            {
+                _tapCount++;
+                if (_tapCount >= 3)
+                {
+                    _panel.SetActive(!_panel.activeSelf);
+                    _tapCount = 0;
+                }
+            }
+            else
+            {
+                _tapCount = 1;
+            }
+
+            _lastTapTime = Time.unscaledTime;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Core/Economy/Balancing/BigNumber.cs
+++ b/Assets/Scripts/Core/Economy/Balancing/BigNumber.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Globalization;
+using UnityEngine;
+
+namespace Game.Core.Economy.Balancing
+{
+    /// <summary>
+    /// Represents large values with helper methods for idle game scale numbers.
+    /// Stores values internally as double while providing utility for formatting and safe arithmetic.
+    /// </summary>
+    [Serializable]
+    public struct BigNumber : IComparable<BigNumber>, IEquatable<BigNumber>
+    {
+        private const double Epsilon = 1e-9;
+        [SerializeField] private double _value;
+
+        public BigNumber(double value)
+        {
+            _value = value;
+        }
+
+        public double RawValue => _value;
+
+        public static implicit operator BigNumber(double value) => new BigNumber(value);
+        public static implicit operator double(BigNumber value) => value._value;
+
+        public static BigNumber operator +(BigNumber a, BigNumber b) => new BigNumber(a._value + b._value);
+        public static BigNumber operator -(BigNumber a, BigNumber b) => new BigNumber(a._value - b._value);
+        public static BigNumber operator *(BigNumber a, BigNumber b) => new BigNumber(a._value * b._value);
+        public static BigNumber operator /(BigNumber a, BigNumber b) => new BigNumber(a._value / b._value);
+
+        public static bool operator >(BigNumber a, BigNumber b) => a._value > b._value + Epsilon;
+        public static bool operator <(BigNumber a, BigNumber b) => a._value + Epsilon < b._value;
+        public static bool operator >=(BigNumber a, BigNumber b) => a._value >= b._value - Epsilon;
+        public static bool operator <=(BigNumber a, BigNumber b) => a._value <= b._value + Epsilon;
+
+        public static BigNumber Max(BigNumber a, BigNumber b) => a >= b ? a : b;
+        public static BigNumber Min(BigNumber a, BigNumber b) => a <= b ? a : b;
+
+        public string ToAbbreviatedString(int decimals = 1)
+        {
+            return Format(_value, decimals);
+        }
+
+        public override string ToString()
+        {
+            return ToAbbreviatedString(2);
+        }
+
+        public static string Format(double value, int decimals)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                return "0";
+            }
+
+            var abs = Math.Abs(value);
+            if (abs < 1000d)
+            {
+                return Math.Round(value, decimals).ToString("N" + decimals, CultureInfo.InvariantCulture);
+            }
+
+            string[] suffixes =
+            {
+                "K", "M", "B", "T", "aa", "ab", "ac", "ad", "ae", "af"
+            };
+
+            int index = -1;
+            while (abs >= 1000d && index < suffixes.Length - 1)
+            {
+                abs /= 1000d;
+                index++;
+            }
+
+            double shortValue = Math.Sign(value) * abs;
+            return string.Format(CultureInfo.InvariantCulture, "{0:F" + Mathf.Clamp(decimals, 0, 3) + "}{1}", shortValue, suffixes[Math.Max(index, 0)]);
+        }
+
+        public int CompareTo(BigNumber other)
+        {
+            return _value.CompareTo(other._value);
+        }
+
+        public bool Equals(BigNumber other)
+        {
+            return Math.Abs(_value - other._value) < Epsilon;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BigNumber number && Equals(number);
+        }
+
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+    }
+}

--- a/Assets/Scripts/Core/Economy/Balancing/CostCurve.cs
+++ b/Assets/Scripts/Core/Economy/Balancing/CostCurve.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Game.Core.Economy.Balancing
+{
+    /// <summary>
+    /// Exponential cost curve used by upgrades and prestige calculations.
+    /// </summary>
+    [Serializable]
+    public class CostCurve
+    {
+        public double StartCost = 1d;
+        public double Growth = 1.1d;
+
+        public double Evaluate(int level)
+        {
+            if (level < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(level));
+            }
+
+            return StartCost * Math.Pow(Growth, level);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Economy/Balancing/MilestoneBonus.cs
+++ b/Assets/Scripts/Core/Economy/Balancing/MilestoneBonus.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Game.Core.Economy.Balancing
+{
+    /// <summary>
+    /// Defines milestone bonus thresholds and percentage boost.
+    /// </summary>
+    [Serializable]
+    public class MilestoneBonus
+    {
+        public int EveryLevels = 25;
+        public double PercentBonus = 15d;
+
+        public double EvaluateMultiplier(int level)
+        {
+            if (EveryLevels <= 0)
+            {
+                return 1d;
+            }
+
+            var milestonesReached = level / EveryLevels;
+            return 1d + milestonesReached * (PercentBonus / 100d);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Economy/CurrencyService.cs
+++ b/Assets/Scripts/Core/Economy/CurrencyService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using Game.Core.Economy.Balancing;
+
+namespace Game.Core.Economy
+{
+    /// <summary>
+    /// Tracks currency balances and raises events when they change.
+    /// </summary>
+    public class CurrencyService
+    {
+        private readonly Dictionary<CurrencyType, BigNumber> _softBalances = new();
+        private readonly Dictionary<CurrencyType, int> _intBalances = new();
+
+        public event Action<CurrencyType, BigNumber> SoftBalanceChanged;
+        public event Action<CurrencyType, int> IntBalanceChanged;
+
+        public CurrencyService()
+        {
+            _softBalances[CurrencyType.Coins] = new BigNumber(0);
+            _softBalances[CurrencyType.Shards] = new BigNumber(0);
+            _intBalances[CurrencyType.Gems] = 0;
+        }
+
+        public BigNumber GetCoins() => GetSoft(CurrencyType.Coins);
+        public BigNumber GetShards() => GetSoft(CurrencyType.Shards);
+        public int GetGems() => _intBalances[CurrencyType.Gems];
+
+        public void SetSoft(CurrencyType type, BigNumber value)
+        {
+            _softBalances[type] = value;
+            SoftBalanceChanged?.Invoke(type, value);
+        }
+
+        public void AddSoft(CurrencyType type, BigNumber delta)
+        {
+            var value = GetSoft(type) + delta;
+            SetSoft(type, value);
+        }
+
+        public bool SpendSoft(CurrencyType type, BigNumber amount)
+        {
+            if (GetSoft(type) < amount)
+            {
+                return false;
+            }
+
+            SetSoft(type, GetSoft(type) - amount);
+            return true;
+        }
+
+        public void SetInt(CurrencyType type, int value)
+        {
+            _intBalances[type] = value;
+            IntBalanceChanged?.Invoke(type, value);
+        }
+
+        public void AddInt(CurrencyType type, int delta)
+        {
+            SetInt(type, GetInt(type) + delta);
+        }
+
+        public bool SpendInt(CurrencyType type, int amount)
+        {
+            if (GetInt(type) < amount)
+            {
+                return false;
+            }
+
+            SetInt(type, GetInt(type) - amount);
+            return true;
+        }
+
+        public BigNumber GetSoft(CurrencyType type)
+        {
+            return _softBalances.TryGetValue(type, out var value) ? value : new BigNumber(0);
+        }
+
+        public int GetInt(CurrencyType type)
+        {
+            return _intBalances.TryGetValue(type, out var value) ? value : 0;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Economy/CurrencyType.cs
+++ b/Assets/Scripts/Core/Economy/CurrencyType.cs
@@ -1,0 +1,9 @@
+namespace Game.Core.Economy
+{
+    public enum CurrencyType
+    {
+        Coins,
+        Gems,
+        Shards
+    }
+}

--- a/Assets/Scripts/Core/Economy/IncomeService.cs
+++ b/Assets/Scripts/Core/Economy/IncomeService.cs
@@ -1,0 +1,67 @@
+using System;
+using Game.Core.Economy.Balancing;
+using Game.Core.Economy.UpgradeSystem;
+using Game.Core.Telemetry;
+
+namespace Game.Core.Economy
+{
+    public class IncomeService
+    {
+        private readonly UpgradeService _upgradeService;
+        private readonly CurrencyService _currencyService;
+        private readonly PrestigeService _prestigeService;
+        private readonly RemoteConfigService _remoteConfigService;
+        private readonly AnalyticsService _analyticsService;
+        private readonly BigNumber _baseTap = new(1d);
+
+        public IncomeService(
+            UpgradeService upgradeService,
+            CurrencyService currencyService,
+            PrestigeService prestigeService,
+            RemoteConfigService remoteConfigService,
+            AnalyticsService analyticsService)
+        {
+            _upgradeService = upgradeService;
+            _currencyService = currencyService;
+            _prestigeService = prestigeService;
+            _remoteConfigService = remoteConfigService;
+            _analyticsService = analyticsService;
+        }
+
+        public BigNumber CalculateIncomePerSecond()
+        {
+            var incomeUpgrade = _upgradeService.GetEffect(UpgradeIds.Income);
+            var tapUpgrade = _upgradeService.GetEffect(UpgradeIds.Tap);
+            var prestigeMult = _prestigeService.GetPrestigeMultiplier();
+            var globalMult = _remoteConfigService.GetDouble(RemoteConfigKeys.GlobalIncomeMultiplier, 1d);
+
+            var baseIncome = _remoteConfigService.GetDouble(RemoteConfigKeys.IncomeBase, 1d);
+            var effectA = _upgradeService.GetEntry(UpgradeIds.Income)?.Definition.EffectExponentA ?? 1d;
+            var effectB = _upgradeService.GetEntry(UpgradeIds.Tap)?.Definition.EffectExponentA ?? 1d;
+            var total = baseIncome * Math.Pow(incomeUpgrade, effectA) * Math.Pow(tapUpgrade, effectB) * prestigeMult * globalMult;
+            return new BigNumber(total);
+        }
+
+        public BigNumber CalculateTapIncome()
+        {
+            var tapEffect = _upgradeService.GetEffect(UpgradeIds.Tap);
+            var prestigeMult = _prestigeService.GetPrestigeMultiplier();
+            return _baseTap * tapEffect * prestigeMult;
+        }
+
+        public void GrantTickIncome(double deltaTime)
+        {
+            var income = CalculateIncomePerSecond().RawValue * deltaTime;
+            _currencyService.AddSoft(CurrencyType.Coins, income);
+            _prestigeService.TrackLifetimeEarnings(income);
+            _analyticsService.LogIncomeTick(income);
+        }
+    }
+
+    public static class UpgradeIds
+    {
+        public const string Income = "income";
+        public const string Tap = "tap";
+        public const string Offline = "offline";
+    }
+}

--- a/Assets/Scripts/Core/Economy/OfflineEarningsService.cs
+++ b/Assets/Scripts/Core/Economy/OfflineEarningsService.cs
@@ -1,0 +1,48 @@
+using System;
+using Game.Core.Economy.Balancing;
+using Game.Core.SaveSystem;
+using Game.Core.Telemetry;
+
+namespace Game.Core.Economy
+{
+    public class OfflineEarningsService
+    {
+        private readonly IncomeService _incomeService;
+        private readonly TimeService _timeService;
+        private readonly RemoteConfigService _remoteConfigService;
+        private readonly AnalyticsService _analyticsService;
+
+        public OfflineEarningsService(
+            IncomeService incomeService,
+            TimeService timeService,
+            RemoteConfigService remoteConfigService,
+            AnalyticsService analyticsService)
+        {
+            _incomeService = incomeService;
+            _timeService = timeService;
+            _remoteConfigService = remoteConfigService;
+            _analyticsService = analyticsService;
+        }
+
+        public BigNumber CalculateOfflineEarnings(SaveData saveData)
+        {
+            var lastQuit = DateTimeOffset.FromUnixTimeSeconds(saveData.LastQuit).UtcDateTime;
+            var lastUptime = TimeSpan.FromSeconds(saveData.LastSavedUptime);
+            var tampered = _timeService.CheckForTampering(lastQuit, lastUptime, out var delta);
+
+            if (tampered)
+            {
+                _analyticsService.LogOfflineEarnings(0, 0, true);
+                return new BigNumber(0);
+            }
+
+            var hoursAway = delta.TotalHours;
+            var maxHours = _remoteConfigService.GetDouble(RemoteConfigKeys.MaxOfflineHours, 10d);
+            var factor = _remoteConfigService.GetDouble(RemoteConfigKeys.OfflineFactor, 0.7d);
+            var clampedHours = Math.Min(hoursAway, maxHours);
+            var earnings = _incomeService.CalculateIncomePerSecond().RawValue * clampedHours * 3600d * factor;
+            _analyticsService.LogOfflineEarnings(hoursAway, earnings, clampedHours < hoursAway);
+            return new BigNumber(earnings);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Economy/PrestigeService.cs
+++ b/Assets/Scripts/Core/Economy/PrestigeService.cs
@@ -1,0 +1,52 @@
+using System;
+using Game.Core.SaveSystem;
+using Game.Core.Telemetry;
+
+namespace Game.Core.Economy
+{
+    public class PrestigeService
+    {
+        private readonly CurrencyService _currencyService;
+        private readonly AnalyticsService _analyticsService;
+        private int _totalShards;
+        private double _lifetimeCoins;
+
+        public PrestigeService(CurrencyService currencyService, AnalyticsService analyticsService)
+        {
+            _currencyService = currencyService;
+            _analyticsService = analyticsService;
+        }
+
+        public void LoadFromSave(SaveData save)
+        {
+            _totalShards = save.Shards;
+            _lifetimeCoins = save.TotalLifetimeCoins;
+        }
+
+        public void TrackLifetimeEarnings(double coins)
+        {
+            _lifetimeCoins += coins;
+        }
+
+        public double GetPrestigeMultiplier()
+        {
+            return 1d + 0.5d * _totalShards;
+        }
+
+        public int CalculateShardsToGain()
+        {
+            return (int)Math.Floor(Math.Log10(_lifetimeCoins + 1));
+        }
+
+        public void ApplyPrestige()
+        {
+            int shards = CalculateShardsToGain();
+            _totalShards += shards;
+            _currencyService.SetSoft(CurrencyType.Coins, 0);
+            _analyticsService.LogPrestige(shards, _totalShards, _lifetimeCoins);
+        }
+
+        public int GetTotalShards() => _totalShards;
+        public double GetLifetimeCoins() => _lifetimeCoins;
+    }
+}

--- a/Assets/Scripts/Core/Economy/UpgradeSystem/UpgradeDefinition.cs
+++ b/Assets/Scripts/Core/Economy/UpgradeSystem/UpgradeDefinition.cs
@@ -1,0 +1,18 @@
+using Game.Core.Economy.Balancing;
+using UnityEngine;
+
+namespace Game.Core.Economy.UpgradeSystem
+{
+    [CreateAssetMenu(menuName = "Game/Upgrade Definition", fileName = "UpgradeDefinition")]
+    public class UpgradeDefinition : ScriptableObject
+    {
+        public string Id;
+        public string DisplayName;
+        public string Description;
+        public CostCurve CostCurve = new();
+        public double BaseEffect = 1d;
+        public double EffectExponentA = 1d;
+        public double EffectExponentB = 1d;
+        public MilestoneBonus MilestoneBonus = new();
+    }
+}

--- a/Assets/Scripts/Core/Economy/UpgradeSystem/UpgradeEntry.cs
+++ b/Assets/Scripts/Core/Economy/UpgradeSystem/UpgradeEntry.cs
@@ -1,0 +1,22 @@
+namespace Game.Core.Economy.UpgradeSystem
+{
+    /// <summary>
+    /// Runtime state for an upgrade.
+    /// </summary>
+    public class UpgradeEntry
+    {
+        public UpgradeDefinition Definition { get; }
+        public int Level { get; private set; }
+
+        public UpgradeEntry(UpgradeDefinition definition, int level)
+        {
+            Definition = definition;
+            Level = level;
+        }
+
+        public void SetLevel(int level)
+        {
+            Level = level;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Economy/UpgradeSystem/UpgradeService.cs
+++ b/Assets/Scripts/Core/Economy/UpgradeSystem/UpgradeService.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using Game.Core.Economy.Balancing;
+
+namespace Game.Core.Economy.UpgradeSystem
+{
+    public class UpgradeService
+    {
+        private readonly Dictionary<string, UpgradeEntry> _entries = new();
+        private readonly CurrencyService _currencyService;
+
+        public UpgradeService(IEnumerable<UpgradeDefinition> definitions, CurrencyService currencyService)
+        {
+            _currencyService = currencyService;
+            foreach (var def in definitions)
+            {
+                _entries[def.Id] = new UpgradeEntry(def, 0);
+            }
+        }
+
+        public event Action<UpgradeEntry> UpgradePurchased;
+
+        public IEnumerable<UpgradeEntry> GetAll() => _entries.Values;
+
+        public UpgradeEntry GetEntry(string id) => _entries.TryGetValue(id, out var entry) ? entry : null;
+
+        public BigNumber GetCost(string id)
+        {
+            var entry = GetEntry(id);
+            if (entry == null)
+            {
+                return new BigNumber(0);
+            }
+
+            return entry.Definition.CostCurve.Evaluate(entry.Level);
+        }
+
+        public double GetEffect(string id)
+        {
+            var entry = GetEntry(id);
+            if (entry == null)
+            {
+                return 1d;
+            }
+
+            var def = entry.Definition;
+            var level = entry.Level;
+            var baseEffect = def.BaseEffect;
+            return baseEffect * Math.Pow(1 + level, def.EffectExponentA);
+        }
+
+        public double GetMilestoneMultiplier(string id)
+        {
+            var entry = GetEntry(id);
+            if (entry == null)
+            {
+                return 1d;
+            }
+
+            return entry.Definition.MilestoneBonus.EvaluateMultiplier(entry.Level);
+        }
+
+        public bool CanBuy(string id)
+        {
+            var cost = GetCost(id);
+            return _currencyService.GetCoins() >= cost;
+        }
+
+        public bool TryBuy(string id)
+        {
+            var entry = GetEntry(id);
+            if (entry == null)
+            {
+                return false;
+            }
+
+            var cost = GetCost(id);
+            if (!_currencyService.SpendSoft(CurrencyType.Coins, cost))
+            {
+                return false;
+            }
+
+            entry.SetLevel(entry.Level + 1);
+            UpgradePurchased?.Invoke(entry);
+            return true;
+        }
+
+        public void SetLevel(string id, int level)
+        {
+            var entry = GetEntry(id);
+            if (entry != null)
+            {
+                entry.SetLevel(level);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,109 @@
+using System.Threading.Tasks;
+using Game.Core.Economy;
+using Game.Core.Economy.UpgradeSystem;
+using Game.Core.Monetization.Ads;
+using Game.Core.Monetization.IAP;
+using Game.Core.SaveSystem;
+using Game.Core.Telemetry;
+using UnityEngine;
+
+namespace Game.Core
+{
+    /// <summary>
+    /// Composition root for the idle game. Attach to a bootstrap object in Bootstrap scene.
+    /// </summary>
+    public class GameManager : MonoBehaviour
+    {
+        [SerializeField] private UpgradeDefinition[] _upgradeDefinitions;
+        [SerializeField] private AdConfigSO _adConfig;
+        [SerializeField] private IAPConfigSO _iapConfig;
+        [SerializeField] private TickService _tickService;
+
+        private CurrencyService _currencyService;
+        private UpgradeService _upgradeService;
+        private IncomeService _incomeService;
+        private PrestigeService _prestigeService;
+        private RemoteConfigService _remoteConfigService;
+        private AnalyticsService _analyticsService;
+        private OfflineEarningsService _offlineEarningsService;
+        private AdService _adService;
+        private IAPService _iapService;
+        private SaveService _saveService;
+        private TimeService _timeService;
+
+        public static GameManager Instance { get; private set; }
+
+        private async void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            Application.targetFrameRate = 60;
+            QualitySettings.vSyncCount = 0;
+
+            _analyticsService = new AnalyticsService();
+            _remoteConfigService = new RemoteConfigService();
+            await _remoteConfigService.InitializeAsync();
+
+            _currencyService = new CurrencyService();
+            _prestigeService = new PrestigeService(_currencyService, _analyticsService);
+            _upgradeService = new UpgradeService(_upgradeDefinitions, _currencyService);
+            _timeService = new TimeService();
+            _incomeService = new IncomeService(_upgradeService, _currencyService, _prestigeService, _remoteConfigService, _analyticsService);
+            _offlineEarningsService = new OfflineEarningsService(_incomeService, _timeService, _remoteConfigService, _analyticsService);
+            _adService = new AdService(_adConfig, _analyticsService, _remoteConfigService);
+            _iapService = new IAPService(_iapConfig, _analyticsService);
+            _saveService = new SaveService(new PlayerPrefsSaveProvider());
+            await _saveService.LoadAsync();
+
+            HookTick();
+        }
+
+        private void HookTick()
+        {
+            if (_tickService != null)
+            {
+                _tickService.Tick += OnTick;
+            }
+        }
+
+        private void OnTick(double delta)
+        {
+            _incomeService.GrantTickIncome(delta);
+        }
+
+        private async void OnApplicationPause(bool pause)
+        {
+            if (pause)
+            {
+                await _saveService.SaveAsync();
+            }
+        }
+
+        private async void OnApplicationQuit()
+        {
+            await _saveService.SaveAsync();
+        }
+    }
+
+    internal class PlayerPrefsSaveProvider : ISaveProvider
+    {
+        public Task SaveAsync(string data)
+        {
+            PlayerPrefs.SetString("save", data);
+            PlayerPrefs.Save();
+            return Task.CompletedTask;
+        }
+
+        public Task<string> LoadAsync()
+        {
+            var data = PlayerPrefs.GetString("save", string.Empty);
+            return Task.FromResult(data);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Monetization/Ads/AdConfigSO.cs
+++ b/Assets/Scripts/Core/Monetization/Ads/AdConfigSO.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace Game.Core.Monetization.Ads
+{
+    [CreateAssetMenu(menuName = "Game/Ad Config", fileName = "AdConfig")]
+    public class AdConfigSO : ScriptableObject
+    {
+        public string AndroidRewardedId = "ca-app-pub-3940256099942544/5224354917";
+        public string IOSRewardedId = "";
+    }
+}

--- a/Assets/Scripts/Core/Monetization/Ads/AdService.cs
+++ b/Assets/Scripts/Core/Monetization/Ads/AdService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using Game.Core.Telemetry;
+using UnityEngine;
+
+namespace Game.Core.Monetization.Ads
+{
+    public enum RewardedAdType
+    {
+        DoubleIncome,
+        Shard
+    }
+
+    public class AdService
+    {
+        private readonly AdConfigSO _config;
+        private readonly AnalyticsService _analyticsService;
+        private readonly RemoteConfigService _remoteConfigService;
+        private DateTime _lastRewarded;
+        private int _shardRewardsToday;
+
+        public event Action<RewardedAdType> RewardGranted;
+
+        public AdService(AdConfigSO config, AnalyticsService analyticsService, RemoteConfigService remoteConfigService)
+        {
+            _config = config;
+            _analyticsService = analyticsService;
+            _remoteConfigService = remoteConfigService;
+        }
+
+        public bool CanShow(RewardedAdType type)
+        {
+            var cooldown = TimeSpan.FromMinutes(_remoteConfigService.GetDouble(RemoteConfigKeys.RewardedCooldownMin, 10));
+            if (type == RewardedAdType.Shard)
+            {
+                var cap = _remoteConfigService.GetInt(RemoteConfigKeys.RewardedShardDailyCap, 3);
+                if (_shardRewardsToday >= cap)
+                {
+                    return false;
+                }
+            }
+
+            return DateTime.UtcNow - _lastRewarded > cooldown;
+        }
+
+        public async Task ShowRewardedAsync(RewardedAdType type)
+        {
+            if (!CanShow(type))
+            {
+                Debug.Log("Ad not ready");
+                return;
+            }
+
+            await Task.Delay(1000); // Simulate ad
+            GrantReward(type);
+        }
+
+        private void GrantReward(RewardedAdType type)
+        {
+            _lastRewarded = DateTime.UtcNow;
+            if (type == RewardedAdType.Shard)
+            {
+                _shardRewardsToday++;
+            }
+
+            RewardGranted?.Invoke(type);
+            _analyticsService.LogAdReward(type.ToString().ToLowerInvariant(), 1, 0);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Monetization/IAP/IAPConfigSO.cs
+++ b/Assets/Scripts/Core/Monetization/IAP/IAPConfigSO.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace Game.Core.Monetization.IAP
+{
+    [CreateAssetMenu(menuName = "Game/IAP Config", fileName = "IAPConfig")]
+    public class IAPConfigSO : ScriptableObject
+    {
+        [System.Serializable]
+        public class ProductInfo
+        {
+            public string ProductId;
+            public string Title;
+            public string Description;
+            public string PriceString;
+        }
+
+        public ProductInfo[] Products;
+    }
+}

--- a/Assets/Scripts/Core/Monetization/IAP/IAPProductIds.cs
+++ b/Assets/Scripts/Core/Monetization/IAP/IAPProductIds.cs
@@ -1,0 +1,9 @@
+namespace Game.Core.Monetization.IAP
+{
+    public static class IAPProductIds
+    {
+        public const string StarterPack = "com.leon.idle.starterpack";
+        public const string RemoveAds = "com.leon.idle.removeads";
+        public const string MonthlyBooster = "com.leon.idle.monthlybooster";
+    }
+}

--- a/Assets/Scripts/Core/Monetization/IAP/IAPService.cs
+++ b/Assets/Scripts/Core/Monetization/IAP/IAPService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using Game.Core.Telemetry;
+using UnityEngine.Purchasing;
+using UnityEngine.Purchasing.Extension;
+
+namespace Game.Core.Monetization.IAP
+{
+    /// <summary>
+    /// Handles Unity IAP initialization and purchase processing.
+    /// </summary>
+    public class IAPService : IStoreListener
+    {
+        private IStoreController _controller;
+        private IExtensionProvider _extensions;
+        private readonly IAPConfigSO _config;
+        private readonly AnalyticsService _analyticsService;
+        private readonly Dictionary<string, Action> _productRewards = new();
+
+        public bool IsInitialized => _controller != null;
+
+        public IAPService(IAPConfigSO config, AnalyticsService analyticsService)
+        {
+            _config = config;
+            _analyticsService = analyticsService;
+        }
+
+        public void RegisterReward(string productId, Action reward)
+        {
+            _productRewards[productId] = reward;
+        }
+
+        public void Initialize()
+        {
+            if (IsInitialized)
+            {
+                return;
+            }
+
+            var builder = ConfigurationBuilder.Instance(StandardPurchasingModule.Instance());
+            if (_config?.Products != null)
+            {
+                foreach (var product in _config.Products)
+                {
+                    builder.AddProduct(product.ProductId, ProductType.NonConsumable);
+                }
+            }
+
+            UnityPurchasing.Initialize(this, builder);
+        }
+
+        public void Purchase(string productId)
+        {
+            if (!IsInitialized)
+            {
+                Initialize();
+                return;
+            }
+
+            _controller?.InitiatePurchase(productId);
+        }
+
+        public void OnInitialized(IStoreController controller, IExtensionProvider extensions)
+        {
+            _controller = controller;
+            _extensions = extensions;
+        }
+
+        public void OnInitializeFailed(InitializationFailureReason error)
+        {
+            UnityEngine.Debug.LogError($"IAP init failed {error}");
+        }
+
+        public PurchaseProcessingResult ProcessPurchase(PurchaseEventArgs e)
+        {
+            if (_productRewards.TryGetValue(e.purchasedProduct.definition.id, out var reward))
+            {
+                reward?.Invoke();
+            }
+
+            _analyticsService.LogIAPPurchase(e.purchasedProduct.definition.id, e.purchasedProduct.metadata.localizedPriceString, e.purchasedProduct.metadata.isoCurrencyCode);
+            return PurchaseProcessingResult.Complete;
+        }
+
+        public void OnPurchaseFailed(Product product, PurchaseFailureReason failureReason)
+        {
+            UnityEngine.Debug.LogWarning($"Purchase failed {failureReason}");
+        }
+    }
+}

--- a/Assets/Scripts/Core/SaveSystem/ISaveProvider.cs
+++ b/Assets/Scripts/Core/SaveSystem/ISaveProvider.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace Game.Core.SaveSystem
+{
+    public interface ISaveProvider
+    {
+        Task SaveAsync(string data);
+        Task<string> LoadAsync();
+    }
+}

--- a/Assets/Scripts/Core/SaveSystem/SaveData.cs
+++ b/Assets/Scripts/Core/SaveSystem/SaveData.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Core.SaveSystem
+{
+    [Serializable]
+    public class SaveData
+    {
+        [Serializable]
+        public class UpgradeState
+        {
+            public string Id;
+            public int Level;
+        }
+
+        public int Version = 1;
+        public double Coins;
+        public int Gems;
+        public double TotalLifetimeCoins;
+        public List<UpgradeState> Upgrades = new();
+        public int Shards;
+        public double DoubleIncomeRemaining;
+        public long LastQuit;
+        public long LastTick;
+        public int AdShardsClaimedToday;
+        public bool RemoveAdsOwned;
+        public long MonthlyBoosterExpiryUtc;
+        public long LastSavedTime;
+        public double LastSavedUptime;
+        public bool TimeTamperFlag;
+    }
+}

--- a/Assets/Scripts/Core/SaveSystem/SaveService.cs
+++ b/Assets/Scripts/Core/SaveSystem/SaveService.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Game.Core.SaveSystem
+{
+    /// <summary>
+    /// Handles serialization and persistence of SaveData with lightweight XOR encryption.
+    /// </summary>
+    public class SaveService
+    {
+        private readonly ISaveProvider _provider;
+        private readonly byte[] _xorKey = Encoding.UTF8.GetBytes("growth-key");
+        private SaveData _current;
+
+        public SaveService(ISaveProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public SaveData Current => _current;
+
+        public async Task LoadAsync()
+        {
+            var raw = await _provider.LoadAsync();
+            if (string.IsNullOrEmpty(raw))
+            {
+                _current = new SaveData();
+                return;
+            }
+
+            var json = Decrypt(raw);
+            _current = JsonUtility.FromJson<SaveData>(json) ?? new SaveData();
+        }
+
+        public async Task SaveAsync()
+        {
+            if (_current == null)
+            {
+                return;
+            }
+
+            var json = JsonUtility.ToJson(_current);
+            var encrypted = Encrypt(json);
+            await _provider.SaveAsync(encrypted);
+        }
+
+        public void UpdateSave(Func<SaveData, SaveData> updater)
+        {
+            _current = updater.Invoke(_current ?? new SaveData());
+        }
+
+        private string Encrypt(string data)
+        {
+            var bytes = Encoding.UTF8.GetBytes(data);
+            XorInPlace(bytes);
+            return Convert.ToBase64String(bytes);
+        }
+
+        private string Decrypt(string data)
+        {
+            try
+            {
+                var bytes = Convert.FromBase64String(data);
+                XorInPlace(bytes);
+                return Encoding.UTF8.GetString(bytes);
+            }
+            catch (FormatException)
+            {
+                Debug.LogWarning("Save data corrupt, resetting");
+                return string.Empty;
+            }
+        }
+
+        private void XorInPlace(IList<byte> bytes)
+        {
+            for (int i = 0; i < bytes.Count; i++)
+            {
+                bytes[i] = (byte)(bytes[i] ^ _xorKey[i % _xorKey.Length]);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Telemetry/AnalyticsKeys.cs
+++ b/Assets/Scripts/Core/Telemetry/AnalyticsKeys.cs
@@ -1,0 +1,15 @@
+namespace Game.Core.Telemetry
+{
+    public static class AnalyticsKeys
+    {
+        public const string SessionStart = "session_start";
+        public const string UpgradePurchase = "upgrade_purchase";
+        public const string Tap = "tap";
+        public const string IncomeTick = "income_tick";
+        public const string Prestige = "prestige";
+        public const string AdReward = "ad_reward";
+        public const string IAPPurchase = "iap_purchase";
+        public const string OfflineEarnings = "offline_earnings";
+        public const string RemoteConfigFetch = "rc_fetch";
+    }
+}

--- a/Assets/Scripts/Core/Telemetry/AnalyticsService.cs
+++ b/Assets/Scripts/Core/Telemetry/AnalyticsService.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Game.Core.Telemetry
+{
+    /// <summary>
+    /// Thin wrapper around Firebase Analytics. Stubs are used to keep compilation without the SDK.
+    /// </summary>
+    public class AnalyticsService
+    {
+        public void LogEvent(string key, Dictionary<string, object> parameters = null)
+        {
+            // TODO: Hook up Firebase Analytics
+#if UNITY_EDITOR || DEV
+            if (parameters != null)
+            {
+                foreach (var kvp in parameters)
+                {
+                    Debug.Log($"Analytics Event {key} {kvp.Key}:{kvp.Value}");
+                }
+            }
+            else
+            {
+                Debug.Log($"Analytics Event {key}");
+            }
+#endif
+        }
+
+        public void LogSessionStart()
+        {
+            LogEvent(AnalyticsKeys.SessionStart);
+        }
+
+        public void LogUpgradePurchase(string id, int level, double cost)
+        {
+            LogEvent(AnalyticsKeys.UpgradePurchase, new Dictionary<string, object>
+            {
+                {"id", id },
+                {"level", level },
+                {"cost", cost }
+            });
+        }
+
+        public void LogTap(double value)
+        {
+            LogEvent(AnalyticsKeys.Tap, new Dictionary<string, object>
+            {
+                {"value", value }
+            });
+        }
+
+        public void LogIncomeTick(double incomePerSecond)
+        {
+            LogEvent(AnalyticsKeys.IncomeTick, new Dictionary<string, object>
+            {
+                {"income_ps", incomePerSecond }
+            });
+        }
+
+        public void LogPrestige(int shards, int totalShards, double lifetimeCoins)
+        {
+            LogEvent(AnalyticsKeys.Prestige, new Dictionary<string, object>
+            {
+                {"shards_gained", shards },
+                {"total_shards", totalShards },
+                {"lifetime_coins", lifetimeCoins }
+            });
+        }
+
+        public void LogAdReward(string type, double value, double cooldown)
+        {
+            LogEvent(AnalyticsKeys.AdReward, new Dictionary<string, object>
+            {
+                {"type", type },
+                {"value", value },
+                {"cooldown_remaining", cooldown }
+            });
+        }
+
+        public void LogIAPPurchase(string productId, string price, string currency)
+        {
+            LogEvent(AnalyticsKeys.IAPPurchase, new Dictionary<string, object>
+            {
+                {"product_id", productId },
+                {"price", price },
+                {"iso_currency", currency }
+            });
+        }
+
+        public void LogOfflineEarnings(double hours, double earnings, bool clamped)
+        {
+            LogEvent(AnalyticsKeys.OfflineEarnings, new Dictionary<string, object>
+            {
+                {"hours", hours },
+                {"earnings", earnings },
+                {"clamped_by_cap", clamped }
+            });
+        }
+
+        public void LogRemoteConfigFetch(bool success, long latencyMs)
+        {
+            LogEvent(AnalyticsKeys.RemoteConfigFetch, new Dictionary<string, object>
+            {
+                {"success", success },
+                {"latency_ms", latencyMs }
+            });
+        }
+    }
+}

--- a/Assets/Scripts/Core/Telemetry/RemoteConfigKeys.cs
+++ b/Assets/Scripts/Core/Telemetry/RemoteConfigKeys.cs
@@ -1,0 +1,20 @@
+namespace Game.Core.Telemetry
+{
+    public static class RemoteConfigKeys
+    {
+        public const string IncomeBase = "income_base";
+        public const string GrowthIncome = "growth_income";
+        public const string GrowthTap = "growth_tap";
+        public const string GrowthOffline = "growth_offline";
+        public const string OfflineFactor = "offline_factor";
+        public const string MaxOfflineHours = "max_offline_hours";
+        public const string MilestoneEveryLevels = "milestone_every_levels";
+        public const string MilestoneBonusPercent = "milestone_bonus_percent";
+        public const string RewardedCooldownMin = "rewarded_cooldown_min";
+        public const string RewardedShardDailyCap = "rewarded_shard_daily_cap";
+        public const string GlobalIncomeMultiplier = "global_income_multiplier";
+        public const string AbFeatureInterstitials = "ab_feature_interstitials";
+        public const string AbBoosterPercent = "ab_booster_percent";
+        public const string OfferFirstSessionDelay = "offer_first_session_delay_s";
+    }
+}

--- a/Assets/Scripts/Core/Telemetry/RemoteConfigService.cs
+++ b/Assets/Scripts/Core/Telemetry/RemoteConfigService.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Game.Core.Telemetry
+{
+    /// <summary>
+    /// Provides remote configuration values backed by Firebase Remote Config.
+    /// Currently implemented as a stub with async simulation.
+    /// </summary>
+    public class RemoteConfigService
+    {
+        private readonly Dictionary<string, object> _values = new();
+        private bool _initialized;
+
+        public async Task InitializeAsync()
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                await Task.Delay(200); // Simulate async fetch
+                ApplyDefaults();
+                _initialized = true;
+                stopwatch.Stop();
+                Debug.Log($"RemoteConfig initialized in {stopwatch.ElapsedMilliseconds}ms");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"RemoteConfig fetch failed: {ex.Message}");
+            }
+        }
+
+        private void ApplyDefaults()
+        {
+            Set(RemoteConfigKeys.IncomeBase, 1d);
+            Set(RemoteConfigKeys.GrowthIncome, 1.12d);
+            Set(RemoteConfigKeys.GrowthTap, 1.10d);
+            Set(RemoteConfigKeys.GrowthOffline, 1.13d);
+            Set(RemoteConfigKeys.OfflineFactor, 0.7d);
+            Set(RemoteConfigKeys.MaxOfflineHours, 10d);
+            Set(RemoteConfigKeys.MilestoneEveryLevels, 25);
+            Set(RemoteConfigKeys.MilestoneBonusPercent, 15d);
+            Set(RemoteConfigKeys.RewardedCooldownMin, 10d);
+            Set(RemoteConfigKeys.RewardedShardDailyCap, 3);
+            Set(RemoteConfigKeys.GlobalIncomeMultiplier, 1d);
+            Set(RemoteConfigKeys.AbFeatureInterstitials, false);
+            Set(RemoteConfigKeys.AbBoosterPercent, 10d);
+            Set(RemoteConfigKeys.OfferFirstSessionDelay, 420);
+        }
+
+        private void Set(string key, object value)
+        {
+            _values[key] = value;
+        }
+
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                ApplyDefaults();
+            }
+        }
+
+        public double GetDouble(string key, double defaultValue)
+        {
+            EnsureInitialized();
+            if (_values.TryGetValue(key, out var value) && value is double doubleValue)
+            {
+                return doubleValue;
+            }
+
+            if (_values.TryGetValue(key, out value) && value is float floatValue)
+            {
+                return floatValue;
+            }
+
+            if (_values.TryGetValue(key, out value) && value is int intValue)
+            {
+                return intValue;
+            }
+
+            return defaultValue;
+        }
+
+        public int GetInt(string key, int defaultValue)
+        {
+            EnsureInitialized();
+            if (_values.TryGetValue(key, out var value))
+            {
+                if (value is int intValue)
+                {
+                    return intValue;
+                }
+
+                if (value is double doubleValue)
+                {
+                    return (int)Math.Round(doubleValue);
+                }
+            }
+
+            return defaultValue;
+        }
+
+        public bool GetBool(string key, bool defaultValue)
+        {
+            EnsureInitialized();
+            if (_values.TryGetValue(key, out var value) && value is bool boolValue)
+            {
+                return boolValue;
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/Assets/Scripts/Core/TickService.cs
+++ b/Assets/Scripts/Core/TickService.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEngine;
+
+namespace Game.Core
+{
+    /// <summary>
+    /// Drives fixed tick updates decoupled from frame rate.
+    /// </summary>
+    public class TickService : MonoBehaviour
+    {
+        public event Action<double> Tick;
+        [SerializeField] private float _tickRate = 10f;
+        private float _accumulator;
+
+        private void Update()
+        {
+            var delta = Time.unscaledDeltaTime;
+            _accumulator += delta;
+            var step = 1f / Mathf.Max(_tickRate, 0.01f);
+            while (_accumulator >= step)
+            {
+                Tick?.Invoke(step);
+                _accumulator -= step;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/TimeService.cs
+++ b/Assets/Scripts/Core/TimeService.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Game.Core
+{
+    /// <summary>
+    /// Provides access to wall clock and monotonic time. Includes simple heuristics for time tampering detection.
+    /// </summary>
+    public class TimeService
+    {
+        private DateTime _lastRecordedTime;
+        private TimeSpan _lastRecordedUptime;
+        private bool _timeTampered;
+
+        public TimeService()
+        {
+            _lastRecordedTime = DateTime.UtcNow;
+            _lastRecordedUptime = GetAppUptime();
+        }
+
+        public DateTime UtcNow => DateTime.UtcNow;
+
+        public TimeSpan GetAppUptime()
+        {
+            return TimeSpan.FromSeconds(UnityEngine.Time.realtimeSinceStartupAsDouble);
+        }
+
+        public bool CheckForTampering(DateTime previousTime, TimeSpan previousUptime, out TimeSpan delta)
+        {
+            var now = UtcNow;
+            var uptime = GetAppUptime();
+            delta = now - previousTime;
+            var monotonicDelta = uptime - previousUptime;
+
+            if (delta.TotalSeconds < 0 || delta.TotalHours > 24 || monotonicDelta.TotalSeconds < 0)
+            {
+                _timeTampered = true;
+                delta = TimeSpan.Zero;
+                return true;
+            }
+
+            _lastRecordedTime = now;
+            _lastRecordedUptime = uptime;
+            return false;
+        }
+
+        public bool WasTimeTampered() => _timeTampered;
+
+        public void MarkSaved(DateTime savedTime, TimeSpan savedUptime)
+        {
+            _lastRecordedTime = savedTime;
+            _lastRecordedUptime = savedUptime;
+        }
+
+        public (DateTime time, TimeSpan uptime) GetLastRecorded() => (_lastRecordedTime, _lastRecordedUptime);
+    }
+}

--- a/Assets/Scripts/UI/Formatting/NumberFormatter.cs
+++ b/Assets/Scripts/UI/Formatting/NumberFormatter.cs
@@ -1,0 +1,17 @@
+using Game.Core.Economy.Balancing;
+
+namespace Game.UI.Formatting
+{
+    public static class NumberFormatter
+    {
+        public static string Format(double value, int decimals = 1)
+        {
+            return BigNumber.Format(value, decimals);
+        }
+
+        public static string Format(BigNumber value, int decimals = 1)
+        {
+            return value.ToAbbreviatedString(decimals);
+        }
+    }
+}

--- a/Assets/Scripts/UI/Screens/ConsentDialog.cs
+++ b/Assets/Scripts/UI/Screens/ConsentDialog.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.UI.Screens
+{
+    /// <summary>
+    /// Simple consent dialog with placeholder hooks for Google UMP integration.
+    /// </summary>
+    public class ConsentDialog : MonoBehaviour
+    {
+        [SerializeField] private Button _acceptButton;
+        [SerializeField] private Button _declineButton;
+
+        private void Awake()
+        {
+            _acceptButton.onClick.AddListener(() => HandleConsent(true));
+            _declineButton.onClick.AddListener(() => HandleConsent(false));
+        }
+
+        private void OnDestroy()
+        {
+            _acceptButton.onClick.RemoveAllListeners();
+            _declineButton.onClick.RemoveAllListeners();
+        }
+
+        private void HandleConsent(bool accepted)
+        {
+            // TODO: Integrate Google UMP
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/UI/Screens/MainScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainScreen.cs
@@ -1,0 +1,81 @@
+using Game.Core;
+using Game.Core.Economy;
+using Game.Core.Economy.UpgradeSystem;
+using Game.Core.Monetization.Ads;
+using Game.UI.Widgets;
+using UnityEngine;
+
+namespace Game.UI.Screens
+{
+    public class MainScreen : MonoBehaviour
+    {
+        [SerializeField] private CurrencyView _coinsView;
+        [SerializeField] private CurrencyView _gemsView;
+        [SerializeField] private PrestigePanelView _prestigePanel;
+        [SerializeField] private UpgradeCardView[] _upgradeCards;
+
+        private GameManager _gameManager;
+
+        private void Start()
+        {
+            _gameManager = GameManager.Instance;
+            Bind();
+        }
+
+        private void Bind()
+        {
+            var currencyService = typeof(GameManager).GetField("_currencyService", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_gameManager) as CurrencyService;
+            var upgradeService = typeof(GameManager).GetField("_upgradeService", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_gameManager) as UpgradeService;
+            var prestigeService = typeof(GameManager).GetField("_prestigeService", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_gameManager) as PrestigeService;
+
+            if (currencyService == null || upgradeService == null || prestigeService == null)
+            {
+                Debug.LogError("Services not ready");
+                return;
+            }
+
+            _prestigePanel.Initialize(prestigeService);
+            foreach (var entry in upgradeService.GetAll())
+            {
+                foreach (var card in _upgradeCards)
+                {
+                    if (card.name.ToLowerInvariant().Contains(entry.Definition.Id))
+                    {
+                        card.Initialize(entry, upgradeService);
+                    }
+                }
+            }
+
+            currencyService.SoftBalanceChanged += OnSoftBalanceChanged;
+            currencyService.IntBalanceChanged += OnIntBalanceChanged;
+            OnSoftBalanceChanged(CurrencyType.Coins, currencyService.GetCoins());
+            OnIntBalanceChanged(CurrencyType.Gems, currencyService.GetGems());
+        }
+
+        private void OnDestroy()
+        {
+            var currencyService = typeof(GameManager).GetField("_currencyService", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(_gameManager) as CurrencyService;
+            if (currencyService != null)
+            {
+                currencyService.SoftBalanceChanged -= OnSoftBalanceChanged;
+                currencyService.IntBalanceChanged -= OnIntBalanceChanged;
+            }
+        }
+
+        private void OnSoftBalanceChanged(CurrencyType type, BigNumber value)
+        {
+            if (type == CurrencyType.Coins)
+            {
+                _coinsView.SetValue(value);
+            }
+        }
+
+        private void OnIntBalanceChanged(CurrencyType type, int value)
+        {
+            if (type == CurrencyType.Gems)
+            {
+                _gemsView.SetValue(value);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/UX/Haptics.cs
+++ b/Assets/Scripts/UI/UX/Haptics.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace Game.UI.UX
+{
+    public static class Haptics
+    {
+        public static void LightImpact()
+        {
+#if UNITY_ANDROID && !UNITY_EDITOR
+            Handheld.Vibrate();
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/UI/Widgets/CurrencyView.cs
+++ b/Assets/Scripts/UI/Widgets/CurrencyView.cs
@@ -1,0 +1,23 @@
+using Game.Core.Economy;
+using Game.UI.Formatting;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.UI.Widgets
+{
+    public class CurrencyView : MonoBehaviour
+    {
+        [SerializeField] private Text _label;
+        [SerializeField] private CurrencyType _type;
+
+        public void SetValue(BigNumber value)
+        {
+            _label.text = NumberFormatter.Format(value);
+        }
+
+        public void SetValue(int value)
+        {
+            _label.text = value.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Widgets/PrestigePanelView.cs
+++ b/Assets/Scripts/UI/Widgets/PrestigePanelView.cs
@@ -1,0 +1,38 @@
+using Game.Core.Economy;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.UI.Widgets
+{
+    public class PrestigePanelView : MonoBehaviour
+    {
+        [SerializeField] private Text _multiplierLabel;
+        [SerializeField] private Text _shardsLabel;
+        [SerializeField] private Button _prestigeButton;
+        private PrestigeService _prestigeService;
+
+        public void Initialize(PrestigeService service)
+        {
+            _prestigeService = service;
+            Refresh();
+            _prestigeButton.onClick.AddListener(OnPrestige);
+        }
+
+        private void OnDestroy()
+        {
+            _prestigeButton.onClick.RemoveListener(OnPrestige);
+        }
+
+        private void OnPrestige()
+        {
+            _prestigeService.ApplyPrestige();
+            Refresh();
+        }
+
+        private void Refresh()
+        {
+            _multiplierLabel.text = $"x{_prestigeService.GetPrestigeMultiplier():F1}";
+            _shardsLabel.text = $"Gain {_prestigeService.CalculateShardsToGain()}";
+        }
+    }
+}

--- a/Assets/Scripts/UI/Widgets/TimerBadgeView.cs
+++ b/Assets/Scripts/UI/Widgets/TimerBadgeView.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.UI.Widgets
+{
+    public class TimerBadgeView : MonoBehaviour
+    {
+        [SerializeField] private Text _label;
+        private DateTime _expireTime;
+        private bool _active;
+
+        public void StartTimer(TimeSpan duration)
+        {
+            _expireTime = DateTime.UtcNow + duration;
+            _active = true;
+        }
+
+        public void StopTimer()
+        {
+            _active = false;
+            _label.text = string.Empty;
+        }
+
+        private void Update()
+        {
+            if (!_active)
+            {
+                return;
+            }
+
+            var remaining = _expireTime - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+            {
+                _active = false;
+                _label.text = "Ready";
+                return;
+            }
+
+            _label.text = $"{remaining.Minutes:D2}:{remaining.Seconds:D2}";
+        }
+    }
+}

--- a/Assets/Scripts/UI/Widgets/UpgradeCardView.cs
+++ b/Assets/Scripts/UI/Widgets/UpgradeCardView.cs
@@ -1,0 +1,48 @@
+using Game.Core.Economy;
+using Game.Core.Economy.UpgradeSystem;
+using Game.UI.Formatting;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.UI.Widgets
+{
+    public class UpgradeCardView : MonoBehaviour
+    {
+        [SerializeField] private Text _title;
+        [SerializeField] private Text _level;
+        [SerializeField] private Text _description;
+        [SerializeField] private Button _buyButton;
+        [SerializeField] private Text _costLabel;
+        private UpgradeEntry _entry;
+        private UpgradeService _service;
+
+        public void Initialize(UpgradeEntry entry, UpgradeService service)
+        {
+            _entry = entry;
+            _service = service;
+            _title.text = entry.Definition.DisplayName;
+            Refresh();
+            _buyButton.onClick.AddListener(OnBuy);
+        }
+
+        private void OnDestroy()
+        {
+            _buyButton.onClick.RemoveListener(OnBuy);
+        }
+
+        private void OnBuy()
+        {
+            if (_service.TryBuy(_entry.Definition.Id))
+            {
+                Refresh();
+            }
+        }
+
+        private void Refresh()
+        {
+            _level.text = $"Lv {_entry.Level}";
+            _costLabel.text = NumberFormatter.Format(_service.GetCost(_entry.Definition.Id));
+            _description.text = _entry.Definition.Description;
+        }
+    }
+}

--- a/Assets/Scripts/Utils/Disposable.cs
+++ b/Assets/Scripts/Utils/Disposable.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Game.Utils
+{
+    /// <summary>
+    /// Helper to wrap disposable actions.
+    /// </summary>
+    public sealed class Disposable : IDisposable
+    {
+        private readonly Action _onDispose;
+        private bool _disposed;
+
+        public Disposable(Action onDispose)
+        {
+            _onDispose = onDispose;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _onDispose?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Utils/EventBus.cs
+++ b/Assets/Scripts/Utils/EventBus.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace Game.Utils
+{
+    /// <summary>
+    /// Lightweight event bus for decoupled gameplay systems.
+    /// </summary>
+    public class EventBus
+    {
+        private readonly Dictionary<Type, List<Delegate>> _handlers = new();
+
+        public void Subscribe<T>(Action<T> handler)
+        {
+            var type = typeof(T);
+            if (!_handlers.TryGetValue(type, out var list))
+            {
+                list = new List<Delegate>();
+                _handlers[type] = list;
+            }
+
+            list.Add(handler);
+        }
+
+        public void Unsubscribe<T>(Action<T> handler)
+        {
+            var type = typeof(T);
+            if (_handlers.TryGetValue(type, out var list))
+            {
+                list.Remove(handler);
+            }
+        }
+
+        public void Publish<T>(T evt)
+        {
+            var type = typeof(T);
+            if (_handlers.TryGetValue(type, out var list))
+            {
+                foreach (var handler in list)
+                {
+                    if (handler is Action<T> action)
+                    {
+                        action.Invoke(evt);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BigNumberTests.cs
+++ b/Assets/Tests/EditMode/BigNumberTests.cs
@@ -1,0 +1,23 @@
+using Game.Core.Economy.Balancing;
+using NUnit.Framework;
+
+namespace Tests.EditMode
+{
+    public class BigNumberTests
+    {
+        [Test]
+        public void Format_ThousandBoundary_RoundsUp()
+        {
+            var result = BigNumber.Format(999900, 1);
+            Assert.AreEqual("1.0M", result);
+        }
+
+        [Test]
+        public void Compare_Works()
+        {
+            var a = new BigNumber(5);
+            var b = new BigNumber(10);
+            Assert.IsTrue(b > a);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/CostCurveTests.cs
+++ b/Assets/Tests/EditMode/CostCurveTests.cs
@@ -1,0 +1,22 @@
+using Game.Core.Economy.Balancing;
+using NUnit.Framework;
+
+namespace Tests.EditMode
+{
+    public class CostCurveTests
+    {
+        [Test]
+        public void Evaluate_IsMonotonic()
+        {
+            var curve = new CostCurve { StartCost = 10, Growth = 1.1 };
+            Assert.Greater(curve.Evaluate(2), curve.Evaluate(1));
+        }
+
+        [Test]
+        public void Evaluate_LevelZero_EqualsStart()
+        {
+            var curve = new CostCurve { StartCost = 5, Growth = 1.2 };
+            Assert.AreEqual(5, curve.Evaluate(0));
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/IncomeServiceTests.cs
+++ b/Assets/Tests/PlayMode/IncomeServiceTests.cs
@@ -1,0 +1,29 @@
+using Game.Core.Economy;
+using Game.Core.Economy.UpgradeSystem;
+using Game.Core.Telemetry;
+using NUnit.Framework;
+
+namespace Tests.PlayMode
+{
+    public class IncomeServiceTests
+    {
+        [Test]
+        public void Income_Increases_WithUpgrades()
+        {
+            var currency = new CurrencyService();
+            var analytics = new AnalyticsService();
+            var remote = new RemoteConfigService();
+            remote.InitializeAsync().Wait();
+            var prestige = new PrestigeService(currency, analytics);
+            var def = new UpgradeDefinition { Id = UpgradeIds.Income, BaseEffect = 1, EffectExponentA = 1 };
+            var defs = new[] { def, new UpgradeDefinition { Id = UpgradeIds.Tap } };
+            var upgrades = new UpgradeService(defs, currency);
+            var income = new IncomeService(upgrades, currency, prestige, remote, analytics);
+
+            var baseIncome = income.CalculateIncomePerSecond().RawValue;
+            upgrades.SetLevel(UpgradeIds.Income, 10);
+            var improvedIncome = income.CalculateIncomePerSecond().RawValue;
+            Assert.Greater(improvedIncome, baseIncome);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/OfflineEarningsTests.cs
+++ b/Assets/Tests/PlayMode/OfflineEarningsTests.cs
@@ -1,0 +1,28 @@
+using Game.Core;
+using Game.Core.Economy;
+using Game.Core.SaveSystem;
+using Game.Core.Telemetry;
+using NUnit.Framework;
+
+namespace Tests.PlayMode
+{
+    public class OfflineEarningsTests
+    {
+        [Test]
+        public void OfflineEarnings_AreCapped()
+        {
+            var currency = new CurrencyService();
+            var analytics = new AnalyticsService();
+            var remote = new RemoteConfigService();
+            remote.InitializeAsync().Wait();
+            var prestige = new PrestigeService(currency, analytics);
+            var upgrades = new UpgradeService(System.Array.Empty<UpgradeDefinition>(), currency);
+            var income = new IncomeService(upgrades, currency, prestige, remote, analytics);
+            var time = new TimeService();
+            var offline = new OfflineEarningsService(income, time, remote, analytics);
+            var save = new SaveData { LastQuit = System.DateTimeOffset.UtcNow.AddHours(-100).ToUnixTimeSeconds() };
+            var earnings = offline.CalculateOfflineEarnings(save);
+            Assert.LessOrEqual(earnings.RawValue, remote.GetDouble(RemoteConfigKeys.MaxOfflineHours, 10) * 3600);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/PrestigeServiceTests.cs
+++ b/Assets/Tests/PlayMode/PrestigeServiceTests.cs
@@ -1,0 +1,20 @@
+using Game.Core.Economy;
+using Game.Core.Telemetry;
+using NUnit.Framework;
+
+namespace Tests.PlayMode
+{
+    public class PrestigeServiceTests
+    {
+        [Test]
+        public void Shards_Calculation_UsesLog10()
+        {
+            var currency = new CurrencyService();
+            var analytics = new AnalyticsService();
+            var prestige = new PrestigeService(currency, analytics);
+            prestige.TrackLifetimeEarnings(1_000_000);
+            var shards = prestige.CalculateShardsToGain();
+            Assert.AreEqual((int)System.Math.Floor(System.Math.Log10(1_000_000 + 1)), shards);
+        }
+    }
+}

--- a/Assets/Tests/PlayMode/UpgradeServiceTests.cs
+++ b/Assets/Tests/PlayMode/UpgradeServiceTests.cs
@@ -1,0 +1,20 @@
+using Game.Core.Economy;
+using Game.Core.Economy.UpgradeSystem;
+using NUnit.Framework;
+
+namespace Tests.PlayMode
+{
+    public class UpgradeServiceTests
+    {
+        [Test]
+        public void Purchase_DeductsCoins()
+        {
+            var currency = new CurrencyService();
+            currency.AddSoft(CurrencyType.Coins, 1000);
+            var def = new UpgradeDefinition { Id = "test", CostCurve = new Game.Core.Economy.Balancing.CostCurve { StartCost = 100, Growth = 1 } };
+            var upgrades = new UpgradeService(new[] { def }, currency);
+            Assert.IsTrue(upgrades.TryBuy("test"));
+            Assert.Less(currency.GetCoins().RawValue, 1000);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add core economy, monetization, save, analytics, and remote config services for the idle tycoon loop
- implement UI widgets, screens, and debug tooling for upgrades, prestige, and rewarded ads interactions
- create configuration assets, editor utilities, documentation, scenes, and unit tests for core systems

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4fbadf3748325b73a1dc16245c733